### PR TITLE
Opened ivar should be externally accessible

### DIFF
--- a/PullableView/PullableView.h
+++ b/PullableView/PullableView.h
@@ -109,6 +109,11 @@
 @property (readwrite,assign) id<PullableViewDelegate> delegate;
 
 /**
+ The current state of the `PullableView`.
+ */
+@property (readonly, assign) BOOL opened;
+
+/**
  Toggles the state of the PullableView
  @param op New state of the view
  @param anim Flag indicating if the transition should be animated

--- a/PullableView/PullableView.m
+++ b/PullableView/PullableView.m
@@ -15,6 +15,7 @@
 @synthesize animate;
 @synthesize animationDuration;
 @synthesize delegate;
+@synthesize opened;
 
 - (id)initWithFrame:(CGRect)frame
 {


### PR DESCRIPTION
The `opened` ivar should be accessible to the users of the class so that they do not have to use external storage on the hosting class in determining whether or not the PullableView is opened or closed.
