### PR TITLE
Fixed README blog post link

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,1 @@
-UIView subclass that implements pullable behaviour similar to the Notification Center in iOS 5. More information: http://www.crocodella.com.br/2011/01/rpg-like-text-box-with-cocos2d/
+UIView subclass that implements pullable behaviour similar to the Notification Center in iOS 5. More information: http://www.crocodella.com.br/2012/01/a-pullable-view-implementation-like-notification-center/


### PR DESCRIPTION
It was pointing to a post about “RPG-like text box with Cocos2D”, when it's pretty clear that it was meant to point to “A pullable view implementation (like Notification Center)”.
